### PR TITLE
Allow '=' base64 padding for beaconcha.in api key

### DIFF
--- a/config/bitfly-beaconchain-config.go
+++ b/config/bitfly-beaconchain-config.go
@@ -23,7 +23,7 @@ func NewBitflyNodeMetricsConfig() *BitflyNodeMetricsConfig {
 				Description:       "The API key used to authenticate your Beaconcha.in node metrics integration. Can be found in your Beaconcha.in account settings.\n\nPlease visit https://beaconcha.in/user/settings#api to access your account information.",
 				AffectsContainers: []ContainerID{ContainerID_BeaconNode, ContainerID_ValidatorClient},
 				// ensures the string is 28 characters of Base64
-				Regex:              "^[A-Za-z0-9+/]{28}$",
+				Regex:              "^[A-Za-z0-9+/=]{28}$",
 				CanBeBlank:         true,
 				OverwriteOnUpgrade: false,
 			},


### PR DESCRIPTION
My beaconcha.in API key has `=` padding as last character, which is currently refused by Nodeset's hyperdrive tool that uses this code (https://github.com/nodeset-org/hyperdrive/blob/main/hyperdrive-cli/client/global-config.go#L10 ).
This PR allows `=` in the Regex, which is perhaps more liberal than it should be (only at the end), but it's the most readable code variant while still enforcing the 28 character length.
