### PR TITLE
Add EC / BN client logging and better request timeouts

### DIFF
--- a/beacon/client/std-http-client.go
+++ b/beacon/client/std-http-client.go
@@ -6,9 +6,11 @@ type StandardHttpClient struct {
 	*StandardClient
 }
 
-// Create a new client instance
-func NewStandardHttpClient(providerAddress string, timeout time.Duration) *StandardHttpClient {
-	provider := NewBeaconHttpProvider(providerAddress, timeout)
+// Create a new client instance.
+// Most calls will use the fast timeout, but queries to validator status will use the slow timeout since they can be very large.
+// Set a timeout of 0 to disable it.
+func NewStandardHttpClient(providerAddress string, fastTimeout time.Duration, slowTimeout time.Duration) *StandardHttpClient {
+	provider := NewBeaconHttpProvider(providerAddress, fastTimeout, slowTimeout)
 	return &StandardHttpClient{
 		StandardClient: NewStandardClient(provider),
 	}

--- a/config/external-beacon-config.go
+++ b/config/external-beacon-config.go
@@ -14,6 +14,12 @@ type ExternalBeaconConfig struct {
 
 	// The URL of the Prysm gRPC endpoint (only needed if using Prysm VCs)
 	PrysmRpcUrl Parameter[string]
+
+	// Number of seconds to wait for a fast request to complete
+	FastTimeout Parameter[uint64]
+
+	// Number of seconds to wait for a slow request to complete
+	SlowTimeout Parameter[uint64]
 }
 
 // Generates a new ExternalBeaconConfig configuration
@@ -92,6 +98,34 @@ func NewExternalBeaconConfig() *ExternalBeaconConfig {
 				Network_All: "",
 			},
 		},
+
+		FastTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.FastTimeoutID,
+				Name:               "Fast Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be fast and light before timing out the request.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 5,
+			},
+		},
+
+		SlowTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.SlowTimeoutID,
+				Name:               "Slow Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be slow and heavy, either taking a long time to process or returning a large amount of data, before timing out the request. Examples include querying the Beacon Node for the state of a large number of validators.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 30,
+			},
+		},
 	}
 }
 
@@ -106,6 +140,8 @@ func (cfg *ExternalBeaconConfig) GetParameters() []IParameter {
 		&cfg.BeaconNode,
 		&cfg.HttpUrl,
 		&cfg.PrysmRpcUrl,
+		&cfg.FastTimeout,
+		&cfg.SlowTimeout,
 	}
 }
 

--- a/config/external-execution-config.go
+++ b/config/external-execution-config.go
@@ -14,6 +14,12 @@ type ExternalExecutionConfig struct {
 
 	// The URL of the Websocket endpoint
 	WebsocketUrl Parameter[string]
+
+	// Number of seconds to wait for a fast request to complete
+	FastTimeout Parameter[uint64]
+
+	// Number of seconds to wait for a slow request to complete
+	SlowTimeout Parameter[uint64]
 }
 
 // Generates a new ExternalExecutionConfig configuration
@@ -85,6 +91,34 @@ func NewExternalExecutionConfig() *ExternalExecutionConfig {
 				Network_All: "",
 			},
 		},
+
+		FastTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.FastTimeoutID,
+				Name:               "Fast Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be fast and light before timing out the request.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 5,
+			},
+		},
+
+		SlowTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.SlowTimeoutID,
+				Name:               "Slow Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be slow and heavy, either taking a long time to process or returning a large amount of data, before timing out the request. Examples include filtering through Ethereum event logs.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 30,
+			},
+		},
 	}
 }
 
@@ -99,6 +133,8 @@ func (cfg *ExternalExecutionConfig) GetParameters() []IParameter {
 		&cfg.ExecutionClient,
 		&cfg.HttpUrl,
 		&cfg.WebsocketUrl,
+		&cfg.FastTimeout,
+		&cfg.SlowTimeout,
 	}
 }
 

--- a/config/fallback-config.go
+++ b/config/fallback-config.go
@@ -15,6 +15,9 @@ type FallbackConfig struct {
 
 	// The URL of the Prysm gRPC endpoint (only needed if using Prysm VCs)
 	PrysmRpcUrl Parameter[string]
+
+	// The delay when checking a client again after it disconnects during a request
+	ReconnectDelay Parameter[uint64]
 }
 
 // Generates a new FallbackConfig configuration
@@ -73,6 +76,20 @@ func NewFallbackConfig() *FallbackConfig {
 			},
 			Default: map[Network]string{
 				Network_All: "",
+			},
+		},
+
+		ReconnectDelay: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.FallbackReconnectDelayID,
+				Name:               "Reconnect Delay",
+				Description:        "The delay, in seconds, to wait after the primary Execution Client or primary Beacon Node disconnects during a request before trying it again.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 60,
 			},
 		},
 	}

--- a/config/iconfig.go
+++ b/config/iconfig.go
@@ -1,6 +1,22 @@
 package config
 
-import "github.com/rocket-pool/node-manager-core/log"
+import (
+	"time"
+
+	"github.com/rocket-pool/node-manager-core/log"
+)
+
+// Timeout settings for the client
+type ClientTimeouts struct {
+	// The timeout for requests that are expected to be fast
+	FastTimeout time.Duration
+
+	// The timeout for requests that are expected to be slow and require either significant processing or a large return size from the server
+	SlowTimeout time.Duration
+
+	// The delay before rechecking the primary client, if fallbacks support is enabled
+	RecheckDelay time.Duration
+}
 
 // NMC servers typically provide some kind of persistent configuration; it must implement this interface.
 type IConfig interface {
@@ -27,8 +43,14 @@ type IConfig interface {
 	// The URLs for the Execution clients to use
 	GetExecutionClientUrls() (string, string)
 
+	// The timeouts for the Execution clients and manager to use
+	GetExecutionClientTimeouts() ClientTimeouts
+
 	// The URLs for the Beacon nodes to use
 	GetBeaconNodeUrls() (string, string)
+
+	// The timeouts for the Beacon nodes and manager to use
+	GetBeaconNodeTimeouts() ClientTimeouts
 
 	// The configuration for the daemon loggers
 	GetLoggerOptions() log.LoggerOptions

--- a/config/ids/ids.go
+++ b/config/ids/ids.go
@@ -11,6 +11,8 @@ const (
 	PortID                  string = "port"
 	OpenPortID              string = "openPort"
 	HttpUrlID               string = "httpUrl"
+	FastTimeoutID           string = "fastTimeout"
+	SlowTimeoutID           string = "slowTimeout"
 	EcID                    string = "executionClient"
 	BnID                    string = "beaconNode"
 	GraffitiID              string = "graffiti"
@@ -19,14 +21,15 @@ const (
 	CacheSizeID             string = "cacheSize"
 
 	// Logger
-	LoggerLevelID      string = "level"
-	LoggerFormatID     string = "format"
-	LoggerAddSourceID  string = "addSource"
-	LoggerMaxSizeID    string = "maxSize"
-	LoggerMaxBackupsID string = "maxBackups"
-	LoggerMaxAgeID     string = "maxAge"
-	LoggerLocalTimeID  string = "localTime"
-	LoggerCompressID   string = "compress"
+	LoggerLevelID             string = "level"
+	LoggerFormatID            string = "format"
+	LoggerAddSourceID         string = "addSource"
+	LoggerMaxSizeID           string = "maxSize"
+	LoggerMaxBackupsID        string = "maxBackups"
+	LoggerMaxAgeID            string = "maxAge"
+	LoggerLocalTimeID         string = "localTime"
+	LoggerCompressID          string = "compress"
+	LoggerEnableHttpTracingID string = "enableHttpTracing"
 
 	// Besu
 	BesuJvmHeapSizeID   string = "jvmHeapSize"
@@ -48,6 +51,7 @@ const (
 	FallbackUseFallbackClientsID string = "useFallbackClients"
 	FallbackEcHttpUrlID          string = "ecHttpUrl"
 	FallbackBnHttpUrlID          string = "bnHttpUrl"
+	FallbackReconnectDelayID     string = "reconnectDelay"
 
 	// Geth
 	GethEvmTimeoutID  string = "evmTimeout"

--- a/config/local-beacon-config.go
+++ b/config/local-beacon-config.go
@@ -23,6 +23,12 @@ type LocalBeaconConfig struct {
 	// Toggle for forwarding the HTTP API port outside of Docker
 	OpenHttpPort Parameter[RpcPortMode]
 
+	// Number of seconds to wait for a fast request to complete
+	FastTimeout Parameter[uint64]
+
+	// Number of seconds to wait for a slow request to complete
+	SlowTimeout Parameter[uint64]
+
 	// Subconfigs
 	Lighthouse *LighthouseBnConfig
 	Lodestar   *LodestarBnConfig
@@ -138,6 +144,34 @@ func NewLocalBeaconConfig() *LocalBeaconConfig {
 				Network_All: RpcPortMode_Closed,
 			},
 		},
+
+		FastTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.FastTimeoutID,
+				Name:               "Fast Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be fast and light before timing out the request.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 5,
+			},
+		},
+
+		SlowTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.SlowTimeoutID,
+				Name:               "Slow Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be slow and heavy, either taking a long time to process or returning a large amount of data, before timing out the request. Examples include querying the Beacon Node for the state of a large number of validators.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 30,
+			},
+		},
 	}
 
 	cfg.Lighthouse = NewLighthouseBnConfig()
@@ -162,6 +196,8 @@ func (cfg *LocalBeaconConfig) GetParameters() []IParameter {
 		&cfg.P2pPort,
 		&cfg.HttpPort,
 		&cfg.OpenHttpPort,
+		&cfg.FastTimeout,
+		&cfg.SlowTimeout,
 	}
 }
 

--- a/config/local-execution-config.go
+++ b/config/local-execution-config.go
@@ -26,6 +26,12 @@ type LocalExecutionConfig struct {
 	// P2P traffic port
 	P2pPort Parameter[uint16]
 
+	// Number of seconds to wait for a fast request to complete
+	FastTimeout Parameter[uint64]
+
+	// Number of seconds to wait for a slow request to complete
+	SlowTimeout Parameter[uint64]
+
 	// Subconfigs
 	Geth       *GethConfig
 	Nethermind *NethermindConfig
@@ -146,6 +152,34 @@ func NewLocalExecutionConfig() *LocalExecutionConfig {
 				Network_All: 30303,
 			},
 		},
+
+		FastTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.FastTimeoutID,
+				Name:               "Fast Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be fast and light before timing out the request.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 5,
+			},
+		},
+
+		SlowTimeout: Parameter[uint64]{
+			ParameterCommon: &ParameterCommon{
+				ID:                 ids.SlowTimeoutID,
+				Name:               "Slow Timeout",
+				Description:        "Number of seconds to wait for a request to complete that is expected to be slow and heavy, either taking a long time to process or returning a large amount of data, before timing out the request. Examples include filtering through Ethereum event logs.",
+				AffectsContainers:  []ContainerID{ContainerID_Daemon},
+				CanBeBlank:         false,
+				OverwriteOnUpgrade: false,
+			},
+			Default: map[Network]uint64{
+				Network_All: 30,
+			},
+		},
 	}
 
 	// Create the subconfigs
@@ -171,6 +205,8 @@ func (cfg *LocalExecutionConfig) GetParameters() []IParameter {
 		&cfg.EnginePort,
 		&cfg.OpenApiPorts,
 		&cfg.P2pPort,
+		&cfg.FastTimeout,
+		&cfg.SlowTimeout,
 	}
 }
 

--- a/config/logger-config.go
+++ b/config/logger-config.go
@@ -32,6 +32,9 @@ type LoggerConfig struct {
 
 	// Toggle for compressing rotated logs
 	Compress Parameter[bool]
+
+	// Toggle for enabling HTTP request tracing
+	EnableHttpTracing Parameter[bool]
 }
 
 // Generates a new Logger configuration
@@ -174,6 +177,18 @@ func NewLoggerConfig() *LoggerConfig {
 				Network_All: true,
 			},
 		},
+
+		EnableHttpTracing: Parameter[bool]{
+			ParameterCommon: &ParameterCommon{
+				ID:                ids.LoggerEnableHttpTracingID,
+				Name:              "Enable HTTP Tracing",
+				Description:       "When enabled, each step of every HTTP request for the Execution Client and Beacon Node will be logged. This results in very verbose log files, so only enable this when you need to debug HTTP requests to your clients specifically.",
+				AffectsContainers: []ContainerID{ContainerID_Daemon},
+			},
+			Default: map[Network]bool{
+				Network_All: false,
+			},
+		},
 	}
 }
 
@@ -193,6 +208,7 @@ func (cfg *LoggerConfig) GetParameters() []IParameter {
 		&cfg.MaxAge,
 		&cfg.LocalTime,
 		&cfg.Compress,
+		&cfg.EnableHttpTracing,
 	}
 }
 
@@ -204,13 +220,14 @@ func (cfg *LoggerConfig) GetSubconfigs() map[string]IConfigSection {
 // Calculate the default number of Geth peers
 func (cfg *LoggerConfig) GetOptions() log.LoggerOptions {
 	return log.LoggerOptions{
-		MaxSize:    int(cfg.MaxSize.Value),
-		MaxBackups: int(cfg.MaxBackups.Value),
-		MaxAge:     int(cfg.MaxAge.Value),
-		LocalTime:  cfg.LocalTime.Value,
-		Compress:   cfg.Compress.Value,
-		Format:     cfg.Format.Value,
-		Level:      cfg.Level.Value,
-		AddSource:  cfg.AddSource.Value,
+		MaxSize:           int(cfg.MaxSize.Value),
+		MaxBackups:        int(cfg.MaxBackups.Value),
+		MaxAge:            int(cfg.MaxAge.Value),
+		LocalTime:         cfg.LocalTime.Value,
+		Compress:          cfg.Compress.Value,
+		Format:            cfg.Format.Value,
+		Level:             cfg.Level.Value,
+		AddSource:         cfg.AddSource.Value,
+		EnableHttpTracing: cfg.EnableHttpTracing.Value,
 	}
 }

--- a/eth/std-rpc-client.go
+++ b/eth/std-rpc-client.go
@@ -1,0 +1,203 @@
+package eth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http/httptrace"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rocket-pool/node-manager-core/log"
+)
+
+// Standard RPC-based Execution Client binding with logging support, using Geth as the backing client implementation.
+type StandardRpcClient struct {
+	client      *ethclient.Client
+	fastTimeout time.Duration
+	slowTimeout time.Duration
+}
+
+// Creates a new StandardRpcClient instance
+func NewStandardRpcClient(address string, fastTimeout time.Duration, slowTimeout time.Duration) (*StandardRpcClient, error) {
+	client, err := ethclient.Dial(address)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EC binding for [%s]: %w", address, err)
+	}
+	return &StandardRpcClient{
+		client:      client,
+		fastTimeout: fastTimeout,
+		slowTimeout: slowTimeout,
+	}, nil
+}
+
+// CodeAt returns the code of the given account. This is needed to differentiate
+// between contract internal errors and the local chain being out of sync.
+func (m *StandardRpcClient) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "CodeAt")
+	defer cancel()
+	return m.client.CodeAt(ctx, contract, blockNumber)
+}
+
+// CallContract executes an Ethereum contract call with the specified data as the
+// input.
+func (m *StandardRpcClient) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "CallContract")
+	defer cancel()
+	return m.client.CallContract(ctx, call, blockNumber)
+}
+
+// HeaderByHash returns the block header with the given hash.
+func (m *StandardRpcClient) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "HeaderByHash")
+	defer cancel()
+	return m.client.HeaderByHash(ctx, hash)
+}
+
+// HeaderByNumber returns a block header from the current canonical chain. If number is
+// nil, the latest known header is returned.
+func (m *StandardRpcClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "HeaderByNumber")
+	defer cancel()
+	return m.client.HeaderByNumber(ctx, number)
+}
+
+// PendingCodeAt returns the code of the given account in the pending state.
+func (m *StandardRpcClient) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "PendingCodeAt")
+	defer cancel()
+	return m.client.PendingCodeAt(ctx, account)
+}
+
+// PendingNonceAt retrieves the current pending nonce associated with an account.
+func (m *StandardRpcClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "PendingNonceAt")
+	defer cancel()
+	return m.client.PendingNonceAt(ctx, account)
+}
+
+// SuggestGasPrice retrieves the currently suggested gas price to allow a timely
+// execution of a transaction.
+func (m *StandardRpcClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "SuggestGasPrice")
+	defer cancel()
+	return m.client.SuggestGasPrice(ctx)
+}
+
+// SuggestGasTipCap retrieves the currently suggested 1559 priority fee to allow
+// a timely execution of a transaction.
+func (m *StandardRpcClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "SuggestGasTipCap")
+	defer cancel()
+	return m.client.SuggestGasTipCap(ctx)
+}
+
+// EstimateGas tries to estimate the gas needed to execute a specific
+// transaction based on the current pending state of the backend blockchain.
+// There is no guarantee that this is the true gas limit requirement as other
+// transactions may be added or removed by miners, but it should provide a basis
+// for setting a reasonable default.
+func (m *StandardRpcClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "EstimateGas")
+	defer cancel()
+	return m.client.EstimateGas(ctx, call)
+}
+
+// SendTransaction injects the transaction into the pending pool for execution.
+func (m *StandardRpcClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "SendTransaction")
+	defer cancel()
+	return m.client.SendTransaction(ctx, tx)
+}
+
+// FilterLogs executes a log filter operation, blocking during execution and
+// returning all the results in one batch.
+func (m *StandardRpcClient) FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.slowTimeout, "FilterLogs")
+	defer cancel()
+	return m.client.FilterLogs(ctx, query)
+}
+
+// SubscribeFilterLogs creates a background log filtering operation, returning
+// a subscription immediately, which can be used to stream the found events.
+func (m *StandardRpcClient) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "SubscribeFilterLogs")
+	defer cancel()
+	return m.client.SubscribeFilterLogs(ctx, query, ch)
+}
+
+// TransactionReceipt returns the receipt of a transaction by transaction hash.
+// Note that the receipt is not available for pending transactions.
+func (m *StandardRpcClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "TransactionReceipt")
+	defer cancel()
+	return m.client.TransactionReceipt(ctx, txHash)
+}
+
+// BlockNumber returns the most recent block number
+func (m *StandardRpcClient) BlockNumber(ctx context.Context) (uint64, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "BlockNumber")
+	defer cancel()
+	return m.client.BlockNumber(ctx)
+}
+
+// BalanceAt returns the wei balance of the given account.
+// The block number can be nil, in which case the balance is taken from the latest known block.
+func (m *StandardRpcClient) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "BalanceAt")
+	defer cancel()
+	return m.client.BalanceAt(ctx, account, blockNumber)
+}
+
+// TransactionByHash returns the transaction with the given hash.
+func (m *StandardRpcClient) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "TransactionByHash")
+	defer cancel()
+	return m.client.TransactionByHash(ctx, hash)
+}
+
+// NonceAt returns the account nonce of the given account.
+// The block number can be nil, in which case the nonce is taken from the latest known block.
+func (m *StandardRpcClient) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "NonceAt")
+	defer cancel()
+	return m.client.NonceAt(ctx, account, blockNumber)
+}
+
+// SyncProgress retrieves the current progress of the sync algorithm. If there's
+// no sync currently running, it returns nil.
+func (m *StandardRpcClient) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "SyncProgress")
+	defer cancel()
+	return m.client.SyncProgress(ctx)
+}
+
+func (m *StandardRpcClient) ChainID(ctx context.Context) (*big.Int, error) {
+	ctx, cancel := logRequestAndCreateContext(ctx, m.fastTimeout, "ChainID")
+	defer cancel()
+	return m.client.ChainID(ctx)
+}
+
+/// ========================
+/// == Internal Functions ==
+/// ========================
+
+// Logs the request and returns a context with the provided timeout and HTTP tracing enabled if requested
+func logRequestAndCreateContext(ctx context.Context, timeout time.Duration, methodName string) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	logger, _ := log.FromContext(ctx)
+	if logger != nil {
+		logger.Debug("Running EC request",
+			slog.String(log.MethodKey, methodName),
+		)
+		tracer := logger.GetHttpTracer()
+		if tracer != nil {
+			ctx = httptrace.WithClientTrace(ctx, tracer)
+		}
+	}
+	return ctx, cancel
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http/httptrace"
 	"os"
 	"path/filepath"
 
@@ -15,6 +16,7 @@ type Logger struct {
 	*slog.Logger
 	logFile *lumberjack.Logger
 	path    string
+	tracer  *httptrace.ClientTrace
 }
 
 // Creates a new logger that writes out to a log file on disk.
@@ -51,11 +53,16 @@ func NewLogger(logFilePath string, options LoggerOptions) (*Logger, error) {
 	case LogFormat_Logfmt:
 		handler = slog.NewTextHandler(logFile, logOptions)
 	}
-	return &Logger{
+	logger := &Logger{
 		Logger:  slog.New(handler),
 		logFile: logFile,
 		path:    logFilePath,
-	}, nil
+	}
+
+	if options.EnableHttpTracing {
+		logger.tracer = logger.createHttpClientTracer()
+	}
+	return logger, nil
 }
 
 // Creates a new logger that uses the slog default logger, which writes to the terminal instead of a file.
@@ -69,6 +76,11 @@ func NewDefaultLogger() *Logger {
 // Get the path of the file this logger is writing to
 func (l *Logger) GetFilePath() string {
 	return l.path
+}
+
+// Get the HTTP client tracer for this logger if HTTP tracing was enabled
+func (l *Logger) GetHttpTracer() *httptrace.ClientTrace {
+	return l.tracer
 }
 
 // Rotate the log file, migrating the current file to an old backup and starting a new one
@@ -106,4 +118,56 @@ func (l *Logger) CreateContextWithLogger(parent context.Context) context.Context
 func FromContext(ctx context.Context) (*Logger, bool) {
 	log, ok := ctx.Value(ContextLogKey).(*Logger)
 	return log, ok
+}
+
+// ========================
+// === Internal Methods ===
+// ========================
+
+// Creates an HTTP client tracer for logging HTTP client events
+func (l *Logger) createHttpClientTracer() *httptrace.ClientTrace {
+	tracer := &httptrace.ClientTrace{}
+	tracer.ConnectDone = func(network, addr string, err error) {
+		l.Debug("HTTP Connect Done",
+			slog.String("network", network),
+			slog.String("addr", addr),
+			Err(err),
+		)
+	}
+	tracer.DNSDone = func(dnsInfo httptrace.DNSDoneInfo) {
+		l.Debug("HTTP DNS Done",
+			slog.String("addrs", fmt.Sprint(dnsInfo.Addrs)),
+			slog.Bool("coalesced", dnsInfo.Coalesced),
+			Err(dnsInfo.Err),
+		)
+	}
+	tracer.DNSStart = func(dnsInfo httptrace.DNSStartInfo) {
+		l.Debug("HTTP DNS Start",
+			slog.String("host", dnsInfo.Host),
+		)
+	}
+	tracer.GotConn = func(connInfo httptrace.GotConnInfo) {
+		l.Debug("HTTP Got Connection",
+			slog.Bool("reused", connInfo.Reused),
+			slog.Bool("wasIdle", connInfo.WasIdle),
+			slog.Duration("idleTime", connInfo.IdleTime),
+			slog.String("localAddr", connInfo.Conn.LocalAddr().String()),
+			slog.String("remoteAddr", connInfo.Conn.RemoteAddr().String()),
+		)
+	}
+	tracer.GotFirstResponseByte = func() {
+		l.Debug("HTTP Got First Response Byte")
+	}
+	tracer.PutIdleConn = func(err error) {
+		l.Debug("HTTP Put Idle Connection",
+			Err(err),
+		)
+	}
+	tracer.WroteRequest = func(wroteInfo httptrace.WroteRequestInfo) {
+		l.Debug("HTTP Wrote Request",
+			Err(wroteInfo.Err),
+		)
+	}
+
+	return tracer
 }

--- a/log/options.go
+++ b/log/options.go
@@ -44,4 +44,7 @@ type LoggerOptions struct {
 
 	// True to include the source code position of the log statement in log messages
 	AddSource bool
+
+	// True to enable HTTP request tracing
+	EnableHttpTracing bool
 }

--- a/node/services/function-runners.go
+++ b/node/services/function-runners.go
@@ -19,52 +19,67 @@ type function2[ClientType any, ReturnType1 any, ReturnType2 any] func(ClientType
 // Attempts to run a function progressively through each client until one succeeds or they all fail.
 // Expects functions with 1 output and an error; for functions with other signatures, see the other runFunctionX functions.
 func runFunction1[ClientType any, ReturnType any](m iClientManagerImpl[ClientType], ctx context.Context, function function1[ClientType, ReturnType]) (ReturnType, error) {
-	logger, _ := log.FromContext(ctx)
+	// If there's no fallback, just run the function on the primary
+	if !m.IsFallbackEnabled() {
+		return function(m.GetPrimaryClient())
+	}
+
 	var blank ReturnType
+	logger, _ := log.FromContext(ctx)
 	typeName := m.GetClientTypeName()
+
+	// Check the clients for recovery
+	m.RecheckFailTimes(logger)
 
 	// Check if we can use the primary
 	if m.IsPrimaryReady() {
 		// Try to run the function on the primary
 		result, err := function(m.GetPrimaryClient())
-		if err != nil {
-			if isDisconnected(err) {
-				// If it's disconnected, log it and try the fallback
-				m.SetPrimaryReady(false)
-				if m.IsFallbackEnabled() {
-					logger.Warn("Primary "+typeName+" client disconnected, using fallback...", log.Err(err))
-					return runFunction1[ClientType, ReturnType](m, ctx, function)
-				} else {
-					logger.Warn("Primary "+typeName+" disconnected and no fallback is configured.", log.Err(err))
-					return blank, fmt.Errorf("all " + typeName + "s failed")
-				}
-			}
-			// If it's a different error, just return it
+		if err == nil {
+			// If there's no error, return the result
+			return result, nil
+		}
+
+		// If it's not a disconnect error, just return it
+		if !isDisconnected(err) {
 			return blank, err
 		}
-		// If there's no error, return the result
-		return result, nil
+
+		// Log the disconnect and try the fallback if available
+		m.SetPrimaryReady(false)
+		if logger != nil {
+			logger.Warn("Primary "+typeName+" client disconnected, using fallback...", log.Err(err))
+		}
+		return runFunction1[ClientType, ReturnType](m, ctx, function)
 	}
 
+	// Check if we can use the fallback
 	if m.IsFallbackReady() {
 		// Try to run the function on the fallback
 		result, err := function(m.GetFallbackClient())
-		if err != nil {
-			if isDisconnected(err) {
-				// If it's disconnected, log it and try the fallback
-				logger.Warn("Fallback "+typeName+" disconnected", log.Err(err))
-				m.SetFallbackReady(false)
-				return blank, fmt.Errorf("all " + typeName + "s failed")
-			}
+		if err == nil {
+			// If there's no error, return the result
+			return result, nil
+		}
 
-			// If it's a different error, just return it
+		// If it's not a disconnect error, just return it
+		if !isDisconnected(err) {
 			return blank, err
 		}
-		// If there's no error, return the result
-		return result, nil
+
+		// If Log the disconnect and return an error
+		if logger != nil {
+			logger.Warn("Fallback "+typeName+" disconnected", log.Err(err))
+		}
+		m.SetFallbackReady(false)
+		return blank, fmt.Errorf("all " + typeName + "s failed")
 	}
 
-	return blank, fmt.Errorf("no " + typeName + "s were ready")
+	// If neither client is ready, just run the primary
+	if logger != nil {
+		logger.Warn("No " + typeName + "s are ready, forcing use of primary...")
+	}
+	return function(m.GetPrimaryClient())
 }
 
 // Run a function with 0 outputs and an error

--- a/node/services/manager.go
+++ b/node/services/manager.go
@@ -1,5 +1,7 @@
 package services
 
+import "github.com/rocket-pool/node-manager-core/log"
+
 type IClientManager[ClientType any] interface {
 	GetPrimaryClient() ClientType
 	GetFallbackClient() ClientType
@@ -15,4 +17,5 @@ type iClientManagerImpl[ClientType any] interface {
 	// Internal functions
 	SetPrimaryReady(bool)
 	SetFallbackReady(bool)
+	RecheckFailTimes(logger *log.Logger)
 }

--- a/node/services/service-provider.go
+++ b/node/services/service-provider.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	dclient "github.com/docker/docker/client"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/rocket-pool/node-manager-core/beacon/client"
 	"github.com/rocket-pool/node-manager-core/config"
 	"github.com/rocket-pool/node-manager-core/eth"
@@ -42,36 +40,38 @@ type ServiceProvider struct {
 }
 
 // Creates a new ServiceProvider instance based on the given config
-func NewServiceProvider(cfg config.IConfig, clientTimeout time.Duration) (*ServiceProvider, error) {
+func NewServiceProvider(cfg config.IConfig) (*ServiceProvider, error) {
 	resources := cfg.GetNetworkResources()
 
 	// EC Manager
 	var ecManager *ExecutionClientManager
 	primaryEcUrl, fallbackEcUrl := cfg.GetExecutionClientUrls()
-	primaryEc, err := ethclient.Dial(primaryEcUrl)
+	timeouts := cfg.GetExecutionClientTimeouts()
+	primaryEc, err := eth.NewStandardRpcClient(primaryEcUrl, timeouts.FastTimeout, timeouts.SlowTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to primary EC at [%s]: %w", primaryEcUrl, err)
 	}
 	if fallbackEcUrl != "" {
 		// Get the fallback EC url, if applicable
-		fallbackEc, err := ethclient.Dial(fallbackEcUrl)
+		fallbackEc, err := eth.NewStandardRpcClient(fallbackEcUrl, timeouts.FastTimeout, timeouts.SlowTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("error connecting to fallback EC at [%s]: %w", fallbackEcUrl, err)
 		}
-		ecManager = NewExecutionClientManagerWithFallback(primaryEc, fallbackEc, resources.ChainID, clientTimeout)
+		ecManager = NewExecutionClientManagerWithFallback(primaryEc, fallbackEc, resources.ChainID, timeouts.RecheckDelay)
 	} else {
-		ecManager = NewExecutionClientManager(primaryEc, resources.ChainID, clientTimeout)
+		ecManager = NewExecutionClientManager(primaryEc, resources.ChainID)
 	}
 
 	// Beacon manager
 	var bcManager *BeaconClientManager
 	primaryBnUrl, fallbackBnUrl := cfg.GetBeaconNodeUrls()
-	primaryBc := client.NewStandardHttpClient(primaryBnUrl, clientTimeout)
+	timeouts = cfg.GetBeaconNodeTimeouts()
+	primaryBc := client.NewStandardHttpClient(primaryBnUrl, timeouts.FastTimeout, timeouts.SlowTimeout)
 	if fallbackBnUrl != "" {
-		fallbackBc := client.NewStandardHttpClient(fallbackBnUrl, clientTimeout)
-		bcManager = NewBeaconClientManagerWithFallback(primaryBc, fallbackBc, resources.ChainID, clientTimeout)
+		fallbackBc := client.NewStandardHttpClient(fallbackBnUrl, timeouts.FastTimeout, timeouts.SlowTimeout)
+		bcManager = NewBeaconClientManagerWithFallback(primaryBc, fallbackBc, resources.ChainID, timeouts.RecheckDelay)
 	} else {
-		bcManager = NewBeaconClientManager(primaryBc, resources.ChainID, clientTimeout)
+		bcManager = NewBeaconClientManager(primaryBc, resources.ChainID)
 	}
 
 	// Docker client


### PR DESCRIPTION
This PR adds supplemental logging support to the standard EC and BN API bindings, including HTTP tracing if requested. It also refactors the primary / fallback timeout system used by the client managers to make it easier to understand what's going on with the reconnect checks. Finally it adds config parameters for all of the above so users can tweak the new behavior if desired.

This comes from feedback provided by some HD operators while running on Mainnet. They'd like more logging granularity when specifically running requests against the standard EC and BN bindings, so they can diagnose why the daemon(s) can't contact the clients when tools like `cURL` can.